### PR TITLE
rtl8723bu: bump revision to 692edf2

### DIFF
--- a/recipes-bsp/drivers/rtl8723bu.bb
+++ b/recipes-bsp/drivers/rtl8723bu.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://Kconfig;md5=ce4c7adf40ddcf6cfca7ee2b333165f0"
 
 SRC_URI = "git://github.com/lwfinger/rtl8723bu.git;protocol=https"
-SRCREV = "b665e50e1f4ecf818bbb955bef0e215a278f0304"
+SRCREV = "692edf2a9284a14671c0d03927d75856967d5c84"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Compatibility with more recent kernel version (up to 4.11).

Signed-off-by: Ricardo Salveti <ricardo.salveti@linaro.org>