### PR TITLE
rtl8723bu-stih410-b2260: bump SRCREV to support newer kernels

### DIFF
--- a/recipes-bsp/drivers/rtl8723bu-stih410-b2260.bb
+++ b/recipes-bsp/drivers/rtl8723bu-stih410-b2260.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://Kconfig;md5=ce4c7adf40ddcf6cfca7ee2b333165f0"
 
 SRC_URI = "git://github.com/lwfinger/rtl8723bu.git;protocol=https"
-SRCREV = "692edf2a9284a14671c0d03927d75856967d5c84"
+SRCREV = "842f0dc709a6592672ac8c920c7175c24f403154"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
The current revision fails to build with mainline kernel.
It has been fixed upstream to support kernel newer than 4.11.9.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>