### PR TITLE
image_types-st.bbclass: be more permissive in the device tree name

### DIFF
--- a/classes/image_types-st.bbclass
+++ b/classes/image_types-st.bbclass
@@ -43,7 +43,7 @@ st_populate_BOOT() {
     #copy kernel
     mcopy -i ${IMGDEPLOYDIR}/${IMAGE_NAME}.bootimg -s ${DEPLOY_DIR_IMAGE}/uImage ::uImage
     #copy devicetree
-    mcopy -i ${IMGDEPLOYDIR}/${IMAGE_NAME}.bootimg -s ${DEPLOY_DIR_IMAGE}/sti*.dtb ::/
+    mcopy -i ${IMGDEPLOYDIR}/${IMAGE_NAME}.bootimg -s ${DEPLOY_DIR_IMAGE}/*sti*.dtb ::/
 
     #copy boot script
     mcopy -i ${IMGDEPLOYDIR}/${IMAGE_NAME}.bootimg -s ${DEPLOY_DIR_IMAGE}/boot/* ::/


### PR DESCRIPTION
When another kernel is used, the dtb name is controlled by the kernel
recipe. By default, it's usually the kernel image type followed by the
real device tree base name.
The function st_populate_BOOT() hardcodes the dtb name to sti*.dtb and
enforce the prefix to be "sti".
In my own build, using mainline kernel, the dtb name is:
uImage-stih410-b2260.dtb ->
uImage--4.13+git0+9e66317d3c-r0-stih410-b2260-20171006085038.dtb
It's causing a build failure when we reach do_image.
This patch makes the dtb name a bit more permissive in order to use
community kernels.

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>