### PR TITLE
u-boot-sti: bump SRCREV

### DIFF
--- a/recipes-bsp/u-boot/u-boot-sti_2016.09.bb
+++ b/recipes-bsp/u-boot/u-boot-sti_2016.09.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = " \
 "
 
 SRC_URI = "git://github.com/cpriouzeau/STi-U-Boot.git;protocol=https"
-SRCREV = "e8f93c5c6ecf700f8e6d22312598788ffd79967d"
+SRCREV = "45114ee573caae1bbaf4f5060d702ede3d2130cb"
 
 SRC_URI_append_stih410-b2260 = " file://st_b2260_stxh410_sdusb_defconfig "
 


### PR DESCRIPTION
Include 2 commits:
* add boot from USB and SD card
* Increase the size of kernel loadable to 64M

Signed-off-by: Fathi Boudra <fathi.boudra@linaro.org>